### PR TITLE
Io streaming

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -108,7 +108,7 @@ Since I/O pipes and inter-kernel pipes have the same interface, the oneAPI kerne
 
 ### Code Details
 
-In this code sample, we demonstrate the concepts described in the previous section in a trivial way. The first test, in *src/LoopbackTest.hpp*, contains a simple loopback test that demonstrates how to use the fake IO pipes and steam data through a simple main processing kernel.
+In this code sample, we demonstrate the concepts described in the previous section in a trivial way. The first test, in *src/LoopbackTest.hpp*, contains a simple loopback test that demonstrates how to use the fake IO pipes and steam data through a simple main processing kernel. For illustrative purposes, this test also includes code using real IO pipes rather than fake IO pipes. These two versions of the test are delineated by preprocessor directives using the `USE_REAL_IO_PIPES` macro, which is not defined by default.
 
 The second test, in *src/SideChannelTest.hpp* has a main processing kernel (`SideChannelMainKernel`) that constantly streams data in from the input I/O pipe and streams the data out the output I/O pipe. The main processing kernel sends an update to the host anytime it sees a value that matches a given value (`match_num`) through a device-to-host side channel (`MyDeviceToHostSideChannel`). The host can use a host-to-device side channel to update `match_num` as the kernel is processing without exiting and restarting the kernel (`MyHostToDeviceTermSideChannel`). The host also uses a host-to-device side channel to terminate the main processing kernel (`MyHostToDeviceSideChannel`). This is illustrated in the figure below.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/LoopbackTest.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/LoopbackTest.hpp
@@ -6,7 +6,7 @@
 
 #include "FakeIOPipes.hpp"
 
-// If the 'USE_REAL_IO_PIPE' macro is defined, this test will use real IO pipes.
+// If the 'USE_REAL_IO_PIPES' macro is defined, this test will use real IO pipes.
 // To use this, ensure you have a BSP that supports IO pipes.
 // NOTE: define this BEFORE including the LoopbackTest.hpp and
 // SideChannelTest.hpp which will check for the presence of this macro.


### PR DESCRIPTION
# Existing Sample Changes
## Description

Update README in io_streaming code sample to describe the USE_REAL_IO_PIPES macro. This macro was used in the code sample, but previously undocumented.

## Type of change 

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No testing, documentation only.