### PR TITLE
case:14021110301 Don't update state variables in MergeJoin kernel without first validating pipe reads

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/db_utils/MergeJoin.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/db_utils/MergeJoin.hpp
@@ -137,8 +137,11 @@ void MergeJoin() {
 
     //////////////////////////////////////////////////////
     //// state variables
-    move_t1_win = 
-      (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
+    // only update if both t1 and t2 windows come from valid pipe reads
+    if (t1_win_valid && t2_win_valid) {
+      move_t1_win = 
+        (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
+    }
 
     keep_going = !t1_done || !t2_done;
     done_comp = t1_done || t2_done;
@@ -272,8 +275,11 @@ void DuplicateMergeJoin() {
 
     //////////////////////////////////////////////////////
     //// state variables
-    move_t1_win = 
-      (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
+    // only update if both t1 and t2 windows come from valid pipe reads
+    if (t1_win_valid && t2_win_valid) {
+      move_t1_win = 
+        (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
+    }
 
     keep_going = !t1_done || !t2_done;
     done_comp = t1_done || t2_done;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/db_utils/MergeJoin.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/db_utils/MergeJoin.hpp
@@ -139,8 +139,8 @@ void MergeJoin() {
     //// state variables
     // only update if both t1 and t2 windows come from valid pipe reads
     if (t1_win_valid && t2_win_valid) {
-      move_t1_win = 
-        (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
+      move_t1_win =
+          (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
     }
 
     keep_going = !t1_done || !t2_done;
@@ -277,8 +277,8 @@ void DuplicateMergeJoin() {
     //// state variables
     // only update if both t1 and t2 windows come from valid pipe reads
     if (t1_win_valid && t2_win_valid) {
-      move_t1_win = 
-        (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
+      move_t1_win =
+          (t1_win.data.last().PrimaryKey() < t2_win.data.last().PrimaryKey());
     }
 
     keep_going = !t1_done || !t2_done;


### PR DESCRIPTION
# Existing Sample Changes
## Description

The state variable updates in MergeJoin and DuplicateMergeJoin involve a comparison of values from non-blocking pipe reads. These values need to be validated as coming from successful pipe reads before the state is updated.

Fixes Issue# 14021110301

## External Dependencies

none

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Validated by manual build of both emulator and simulator flows for db9 and db12.
